### PR TITLE
metanorma/mn2pdf-ruby#1 'listen' for mn2pdf notifications

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,46 @@
+name: release-tag
+
+on:
+  repository_dispatch:
+    types: [ metanorma/mn2pdf ]
+
+jobs:
+  tag_repo:
+    runs-on: ubuntu-18.04
+    if: startsWith(github.event.client_payload.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v1
+      - name: Add writable remote
+        run: |
+          git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+          git pull github ${GITHUB_REF} --ff-only
+      - name: Parse mn2pdf version
+        env:
+          MN2PDF_TAG: ${{ github.event.client_payload.ref }}
+        run: |
+          echo "::set-env name=MN2PDF_VERSION::${MN2PDF_TAG#*/v}"
+      - name: Use Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          architecture: 'x64'
+      - name: Update version
+          gem install gem-release
+          gem bump ${MN2PDF_VERSION}
+      - name: Update mn2pdf.jar
+        run: |
+          rm -f bin/mn2pdf.jar
+          rake bin/mn2pdf.jar
+      - name: Update gems
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Run specs
+        run: |
+          bundle exec rake
+      - name: Push commit and tag
+        run: |
+          git add lib/mn2pdf/version.rb
+          git commit -m "Bump version to ${MN2PDF_VERSION}"
+          git tag v${MN2PDF_VERSION}
+          git push github HEAD:${GITHUB_REF} --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  tag_repo:
+    runs-on: ubuntu-18.04
+    if: startsWith(github.event.client_payload.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v1
+      - name: Update mn2pdf.jar
+        run: |
+          rm -f bin/mn2pdf.jar
+          rake bin/mn2pdf.jar
+      - name: Update gems
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Run specs
+        run: |
+          bundle exec rake
+      - name: Publish to rubygems.org
+        uses: dawidd6/action-publish-gem@v1
+        with:
+          api_key: ${{secrets.RUBYGEMS_API_KEY}}


### PR DESCRIPTION
 - metanorma/mn2pdf-ruby#1

@ronaldtse 
 - please add `secrets.RUBYGEMS_API_KEY`

@ronaldtse @Intelligent2013 @opoudjis 
 - I have proposal to not commit jar into this repository because after 10-20 commits will explode the size of the repo, or we will need to truncate history. Moreover, we currently have tests and a nice way to get jar before publishing