### PR TITLE
fix: properly handle patch releases vs JAR versions in release-tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,22 +24,30 @@ jobs:
       - name: Parse mn2pdf version
         env:
           MN2PDF_TAG: ${{ github.event.client_payload.ref }}
-        run: echo MN2PDF_VERSION=${MN2PDF_TAG#*/v} >> ${GITHUB_ENV}
+        run: echo "MN2PDF_VERSION=${MN2PDF_TAG#*/v}" >> ${GITHUB_ENV}
 
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ needs.prepare.outputs.default-ruby-version }}
           bundler-cache: true
 
+      - name: Validate JAR exists for version
+        env:
+          MN2PDF_VERSION: ${{ env.MN2PDF_VERSION }}
+        run: bundle exec rake release:validate_jar[${MN2PDF_VERSION}]
+
       - run: rm -f bin/mn2pdf.jar
 
       - run: bundle exec rake
 
-      - run: |
-          gem install gem-release
-          gem bump --version ${MN2PDF_VERSION} --no-commit
+      - name: Bump version
+        env:
+          MN2PDF_VERSION: ${{ env.MN2PDF_VERSION }}
+        run: bundle exec rake release:bump[${MN2PDF_VERSION}]
 
       - name: Push commit and tag
+        env:
+          MN2PDF_VERSION: ${{ env.MN2PDF_VERSION }}
         run: |
           git add -u lib/mn2pdf/version.rb
           git commit -m "Bump version to ${MN2PDF_VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+mn2pdf-ruby is a Ruby gem wrapper around the Java mn2pdf library (mn2pdf.jar) for converting Metanorma XML files into PDF. The gem version mirrors the underlying mn2pdf.jar version.
+
+## Common Commands
+
+```bash
+# Install dependencies
+bundle install
+
+# Run all tests (also downloads bin/mn2pdf.jar if missing)
+rake
+
+# Run tests only
+rake spec
+
+# Download/update the mn2pdf.jar to match version in lib/mn2pdf/version.rb
+rake bin/mn2pdf.jar
+
+# Run a single spec file
+rspec spec/mn2pdf_spec.rb
+
+# Run a specific test
+rspec spec/mn2pdf_spec.rb -e "converts XML to PDF"
+
+# Release the gem
+rake release
+```
+
+## Architecture
+
+- `lib/mn2pdf.rb` - Main module exposing `Mn2pdf.convert()`, `Mn2pdf.help()`, and `Mn2pdf.version()`. Handles argument building, font manifest processing, and error parsing.
+- `lib/mn2pdf/jvm.rb` - JVM wrapper that invokes the Java JAR with appropriate heap (-Xmx3g), stack (-Xss10m), and headless options.
+- `lib/mn2pdf/version.rb` - Contains `VERSION` (gem version) and `MN2PDF_JAR_VERSION` (JAR version). These must be kept in sync.
+- `bin/mn2pdf.jar` - The mn2pdf Java JAR, downloaded via `rake bin/mn2pdf.jar`.
+
+## Updating mn2pdf Version
+
+1. Update `VERSION` and `MN2PDF_JAR_VERSION` in `lib/mn2pdf/version.rb` to the desired version
+2. Run `rake bin/mn2pdf.jar` to verify the JAR downloads successfully
+3. Commit and release with `rake release`

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "open-uri"
+require "yaml"
 require_relative "lib/mn2pdf/version"
 
 RSpec::Core::RakeTask.new(:spec)
@@ -11,17 +12,86 @@ def jar_url(ver)
   "https://github.com/metanorma/mn2pdf/releases/download/v#{ver}/mn2pdf-#{ver}.jar"
 end
 
+def jar_exists?(ver)
+  uri = URI.parse(jar_url(ver))
+  begin
+    uri.open
+    true
+  rescue OpenURI::HTTPError, Errno::ENOENT
+    false
+  end
+end
+
 file "bin/mn2pdf.jar" do |file|
   if Mn2pdf::VERSION != Mn2pdf::MN2PDF_JAR_VERSION
-    begin
-      URI.parse(jar_url(Mn2pdf::VERSION)).open
+    # VERSION differs from MN2PDF_JAR_VERSION - validate VERSION JAR exists
+    # (this is the patch-release scenario where only Ruby version changes)
+    unless jar_exists?(Mn2pdf::VERSION)
       abort(%(MN2PDF_JAR_VERSION in lib/mn2pdf/version.rb is outdated!
-              Assign VERSION to MN2PDF_JAR_VERSION))
-    rescue OpenURI::HTTPError, Errno::ENOENT
-      # expected
+              VERSION #{Mn2pdf::VERSION} JAR not found, but MN2PDF_JAR_VERSION #{Mn2pdf::MN2PDF_JAR_VERSION} exists.
+              Update version.rb: set MN2PDF_JAR_VERSION to the existing Java version.))
     end
   end
   url = jar_url(Mn2pdf::MN2PDF_JAR_VERSION)
-  print "Downloading #{url}..."
+  puts "Downloading #{url}..."
   File.binwrite(file.name, URI.parse(url).read)
+end
+
+namespace :release do
+  desc "Validate that JAR exists for the given version"
+  task :validate_jar, [:version] do |_, args|
+    version = args[:version]
+    if jar_exists?(version)
+      puts "JAR exists for v#{version}"
+      exit 0
+    else
+      puts "JAR does NOT exist for v#{version}"
+      exit 1
+    end
+  end
+
+  desc "Bump version for release"
+  task :bump, [:version] do |_, args|
+    version = args[:version]
+    raise "Usage: rake release:bump[version]" unless version
+
+    version_file = "lib/mn2pdf/version.rb"
+    content = File.read(version_file)
+
+    current_version = Mn2pdf::VERSION
+    current_jar_version = Mn2pdf::MN2PDF_JAR_VERSION
+
+    if jar_exists?(version)
+      # JAR exists for this version - proper release, update both
+      puts "JAR v#{version} exists: updating both VERSION and MN2PDF_JAR_VERSION"
+      content.gsub!(/VERSION = "[^"]+"/, "VERSION = \"#{version}\"")
+      # Handle both MN2PDF_JAR_VERSION = "x.y.z" and MN2PDF_JAR_VERSION = VERSION
+      content.gsub!(/MN2PDF_JAR_VERSION = "[^"]+"/, "MN2PDF_JAR_VERSION = \"#{version}\"")
+      content.gsub!(/MN2PDF_JAR_VERSION = VERSION/, "MN2PDF_JAR_VERSION = \"#{version}\"")
+    else
+      # JAR does not exist - patch release (Ruby-only changes)
+      # Only update VERSION, keep MN2PDF_JAR_VERSION at existing JAR version
+      jar_version = current_jar_version
+      # If MN2PDF_JAR_VERSION was referencing VERSION constant, resolve it
+      if jar_version == current_version
+        # Infer base version: 2.50.1 -> 2.50, 2.51.3 -> 2.51
+        base_version = version.split('.')[0...-1].join('.')
+        if jar_exists?(base_version)
+          jar_version = base_version
+          puts "Inferred JAR version #{jar_version} from #{version}"
+        else
+          abort("Cannot determine JAR version for patch release #{version}. Please set MN2PDF_JAR_VERSION manually.")
+        end
+      end
+
+      puts "JAR v#{version} does NOT exist: patch release, updating only VERSION (MN2PDF_JAR_VERSION stays at #{jar_version})"
+      content.gsub!(/VERSION = "[^"]+"/, "VERSION = \"#{version}\"")
+      content.gsub!(/MN2PDF_JAR_VERSION = "[^"]+"/, "MN2PDF_JAR_VERSION = \"#{jar_version}\"")
+      content.gsub!(/MN2PDF_JAR_VERSION = VERSION/, "MN2PDF_JAR_VERSION = \"#{jar_version}\"")
+    end
+
+    File.write(version_file, content)
+    puts "Updated #{version_file}:"
+    puts content
+  end
 end


### PR DESCRIPTION
## Summary

- Validate that mn2pdf JAR exists for the given version before proceeding with release
- For minor/major bumps (matching JAR version): update both VERSION and MN2PDF_JAR_VERSION
- For patch bumps (Ruby-only API changes): only update VERSION, keep MN2PDF_JAR_VERSION at existing Java version
- Use Ruby script instead of gem bump for precise version file control

## Problem

Previously, when release-tag.yml was triggered with a patch version (e.g., v2.50.1) that does not exist in the mn2pdf Java releases, it would fail with a 404 error when trying to download the JAR.

## Test plan

- Verify the workflow still works for standard releases (e.g., v2.52)
- Verify the workflow handles patch releases correctly (only updating VERSION, not MN2PDF_JAR_VERSION)