### PR TITLE
docs: document versioning pattern and release workflow

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,4 +47,13 @@ rake bin/mn2pdf.jar
 
 Then release the gem with `rake release`.
 
+== Versioning
+
+The gem version (`VERSION`) can be more granular than the mn2pdf JAR version (`MN2PDF_JAR_VERSION`) because the Ruby wrapper may need API changes that don't require a new JAR.
+
+* When `VERSION == MN2PDF_JAR_VERSION`: a synchronized release, both update together
+* When `VERSION` is a patch release (e.g., 2.50.1) but `MN2PDF_JAR_VERSION` is 2.50: the Ruby API changed but no new JAR is needed
+
+The `release-tag.yml` workflow handles this automatically when triggered by the mn2pdf Java repository.
+
 


### PR DESCRIPTION
Document the versioning pattern and release mechanism in README.adoc:

- Explain that Ruby gem versions can be more granular than mn2pdf JAR versions
- Explain the two cases: synchronized releases vs patch releases
- Document that release-tag.yml handles this automatically when triggered by the mn2pdf Java repository