### PR TITLE
cimas sync 2026-08-10 wave (3-week drift catch-up + standoc-models P3)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,30 @@
 # See https://github.com/metanorma/cimas
 inherit_from:
   - https://raw.githubusercontent.com/riboseinc/oss-guides/main/ci/rubocop.yml
+  # .rubocop_todo.yml MUST be the last entry. inherit_from is last-wins:
+  # if listed before oss-guides, the shared config's stricter Metrics/
+  # (MethodLength, BlockLength, etc.) rules override the todo's per-file
+  # grandfathering, and the todo becomes inert on those cops. Empirically
+  # verified on suma 2026-07-06: with todo listed first, 34 Metrics/* offenses
+  # remained; moved last, cleared. Every gem in the metanorma-org fleet
+  # already ships a `.rubocop_todo.yml` on its live tree (audited 2026-07-06,
+  # 54/54 have it), so this reference is safe to emit unconditionally.
+  - .rubocop_todo.yml
+
+# Rubocop plugins enabled centrally so every metanorma-org gem picks them up
+# on cimas sync — best practice belongs at the shared-template layer, not
+# per-repo. Per ronaldtse feedback on metanorma/ci#332.
+plugins:
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-rake
 
 # local repo-specific modifications
 # ...
 
 AllCops:
-  TargetRubyVersion: 3.4
+  # 3.3 matches the org-wide minimum being pushed via #274 (Raise minimum
+  # Ruby version to 3.3 due to EOL of 3.2 on 2026-03-31). Was 3.4 before
+  # this commit — 3.4 was above the org's stated minimum and would have
+  # applied Rubocop rules that fail-close on gems still targeting 3.3.
+  TargetRubyVersion: 3.3

--- a/mn2pdf.gemspec
+++ b/mn2pdf.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n") << "bin/mn2pdf.jar"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Fortnightly cimas sync wave 2026-08-10 (previous 2026-07-22, 3 weeks overdue).

## Wave-scale context

97 of 137 mapped repos have accumulated drift. Key changes this wave:

- **standoc-models P3** monorepo consolidation ([metanorma-core#16](https://github.com/metanorma/metanorma-core/issues/16) / [metanorma/ci#390](https://github.com/metanorma/ci/pull/390)): 16 `metanorma-model-*` entries collapsed into 1 `standoc-models` entry.
- **mn-samples-plateau docker.yml unmap** ([metanorma/ci#388](https://github.com/metanorma/ci/pull/388)): restored @strogonoff's local Firelight customizations after inadvertent cimas-sync strip on mn-samples-plateau#536.
- **ci#375/#376 supersedes** ([metanorma/ci#383](https://github.com/metanorma/ci/pull/383) / [#384](https://github.com/metanorma/ci/pull/384) / [#385](https://github.com/metanorma/ci/pull/385) landed 2026-08-07): reusable workflow shape updates.
- **gh-actions/model/Makefile verify-images defensive check** (ci#302 / #303): applied uniformly across model repos.
- **Various minor drift**: rubocop-todo inherit fix, release.yml bundle install fix (both from prior wave 2026-07-22).

## What to review on this repo

The branch diff shows what cimas synced from current templates. If any change is a clobbered opt-out (per-repo customization that shouldn't have been stripped), flag it and I'll unmap that file in cimas.yml — see the mn-samples-plateau#537 remediation pattern for the shape of the fix.

## Non-scope

- Individual template design changes (those go through their own PRs into metanorma/ci first).
- Wave-scale meta-issues (release scheduling, cadence): tracked via the metanorma/ci queue.

🤖
